### PR TITLE
Feature: Add fix linting to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "mocha",
     "coverage": "nyc mocha --global __coverage__",
     "lint": "eslint .",
+    "fix-lint": "eslint . --fix",
     "prepare": "is-ci || husky install"
   },
   "author": "HN Software",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha",
     "coverage": "nyc mocha --global __coverage__",
     "lint": "eslint .",
-    "fix-lint": "eslint . --fix",
+    "fix-lint": "eslint --fix .",
     "prepare": "is-ci || husky install"
   },
   "author": "HN Software",


### PR DESCRIPTION
## Description

Now we can use `npm run fix-lint` to automatically resolve fixable `eslint` errors.

## Checklist

- [x] My changes are documented
- [x] My changes are tested
- [x] Quality tools pass locally with my changes
