### PR TITLE
Feature: Create github helpers workflow and auto assign job

### DIFF
--- a/.github/workflows/github-helpers.yaml
+++ b/.github/workflows/github-helpers.yaml
@@ -1,0 +1,23 @@
+name: 'github-helpers'
+on:
+  pull_request_target:
+    types: [opened, reopened]
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+jobs:
+  auto-assignee-for-pr:
+    name: auto-assignee-for-pr
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.3.5


### PR DESCRIPTION
## Description

Now we have a new workflow for some Github helpers. Currently one job is created in it. Now, assignee will be automatically assigned to PR creator with.

## Checklist

- [x] My changes are documented
- [x] My changes are tested
- [x] Quality tools pass locally with my changes