### PR TITLE
Chore: Update github quality workflow permissions

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,5 +1,16 @@
 name: 'quality'
 on: 'push'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
 jobs:
   check-lint:
     name: check-lint


### PR DESCRIPTION
## Description

Restrict all kind of permissions for quality workflows. Currently there is no permission needed. Using the least permission needed is a best practice.

`meta` permission is not configured so it uses default `meta` permission which is `read`. It's OK for `meta` to have `read` permission even if it's not in use.

## Checklist

- [x] My changes are documented
- [x] My changes are tested
- [x] Quality tools pass locally with my changes