### PR TITLE
Fix: Fix eslint padding line between statements rule for function expressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -526,6 +526,24 @@
         "blankLine": "any",
         "prev": "cjs-import",
         "next": "cjs-import"
+      },
+      {
+        "blankLine": "always",
+        "prev": [
+          "const",
+          "let",
+          "var"
+        ],
+        "next": "block-like"
+      },
+      {
+        "blankLine": "always",
+        "prev": "block-like",
+        "next": [
+          "const",
+          "let",
+          "var"
+        ]
       }
     ],
     "prefer-exponentiation-operator": "error",


### PR DESCRIPTION
## Description

Padding line rule was not working fine for function expressions.

For the sample code below,

- It was not allowing space after `bar` and before `baz`.
- It was not allowing space between function expressions like `quuz` and `corge`.

With the rule change all these issues has been fixed.

```
const foo = 'foo';
const bar = 'bar';

const baz = () => {
  // Empty
};

const qux = 4;
const quux = true;

const quuz = () => {
  // Empty
};

const corge = () => {
  // Empty
};

baz(
  foo,
  qux
);
quuz(
  bar,
  quux
);
corge();
```

## Checklist

- [x] My changes are documented
- [x] My changes are tested
- [x] Quality tools pass locally with my changes