### PR TITLE
Fix: Fix weird eslint styling caused by new line rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -294,7 +294,9 @@
     // Stylistic Issues Section Start
     "array-bracket-newline": [
       "error",
-      "always"
+      {
+        "minItems": 1
+      }
     ],
     "array-bracket-spacing": "error",
     "array-element-newline": "error",
@@ -323,7 +325,9 @@
     "function-call-argument-newline": "error",
     "function-paren-newline": [
       "error",
-      "always"
+      {
+        "minItems": 1
+      }
     ],
     "id-denylist": "off",
     "id-length": "error",


### PR DESCRIPTION
## Description

What we made with #22 caused some weird styling like

```js
// Bracket newline with no items
const foo = [
];

// Paren newline with no items
const bar = (
) => {
  // Emtpy
}

// More bad styling
baz(
  (
  ) => {
    // Empty
  },
);
```

With this PR we fix that. In git diff it will show 2 lines changed when you edit parameters or array elements and add some but since it will be only once, we are OK with that instead of accepting that weird style. Check #22 for examples.

With minimum 1 items it will now require new line with the rule changes.


Some correct examples after this change:

```js
const foo = [
  1,
];

// Paren newline with no items
const bar = (
  baz,
) => {
  // Emtpy
}

const qux = []

cont quuz = () => {
  // Empty
}
```

## Checklist

- [x] My changes are documented
- [x] My changes are tested
- [x] Quality tools pass locally with my changes